### PR TITLE
25 - Supply endTime to tryn-api

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,10 +22,11 @@ class App extends Component {
       <QueryRenderer
         environment={this.state.environment}
         query={graphql`
-            query AppAllVehiclesQuery($agency: String!, $startTime: String!) {
-              trynState(agency: $agency, startTime: $startTime) {
+            query AppAllVehiclesQuery($agency: String!, $startTime: String!, $endTime: String!) {
+              trynState(agency: $agency, startTime: $startTime, endTime: $endTime) {
                 agency
                 startTime
+                endTime
                 states {
                   ...Map_state
                 }
@@ -35,6 +36,7 @@ class App extends Component {
         variables={{
           agency: 'muni',
           startTime: Date.now() - 15000,
+          endTime: Date.now(),
         }}
         render={({ error, props }) => {
           if (error) {


### PR DESCRIPTION
Thanks to https://github.com/trynmaps/tryn-api/pull/11
we now have to supply the endTime to the API.

This commit supplies the endTime as the current time,
with the startTime staying unchanged as the current
time minus 15 seconds.

Note: ensure that you ran `yarn run relay --watch` before pulling, as it'll update the generated graphql files.