### PR TITLE
12 - Restructure Relay Schema as to correspond to API Changes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,8 +28,8 @@ class App extends Component {
                 agency
                 startTime
                 endTime
-                states {
-                  ...Map_state
+                routes {
+                  ...Map_route
                 }
               }
             }
@@ -43,7 +43,7 @@ class App extends Component {
           if (error) {
             return <div>{error.message}</div>;
           } else if (props) {
-            return <Map state={props.trynState.states[0]} />;
+            return <Map route={props.trynState.routes[0]} />;
           }
           return <div>Loading</div>;
         }}

--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -145,8 +145,8 @@ class Map extends Component {
         {/* Routes component returns DeckGL component with routes and markers layer */}
         <Routes
           onMarkerClick={(lon, lat, info) => this.onMarkerClick(lon, lat, info)}
-          state={this.props.state}
           geojson={geojson}
+          route={this.props.route}
           viewport={viewport}
         />
       </ReactMapGL>
@@ -170,7 +170,7 @@ class Map extends Component {
 }
 
 Map.propTypes = {
-  state: propTypes.shape(
+  route: propTypes.shape(
     propTypes.string,
     propTypes.arrayOf(propTypes.object),
   ).isRequired,
@@ -179,8 +179,8 @@ Map.propTypes = {
 export default createFragmentContainer(
   Map,
   graphql`
-    fragment Map_state on State {
-      ...Routes_state
+    fragment Map_route on Route {
+      ...Routes_route
     }
   `,
 );

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -18,7 +18,7 @@ class Routes extends Component {
     /* returns new DeckGL Icon Layer displaying all stops on given routes */
 
     // Push stop markers into data array
-    const data = this.props.state.routes.filter(r => r.stops).reduce((acc, curr) =>
+    const data = [this.props.route].filter(r => r.stops).reduce((acc, curr) =>
       [...acc, ...curr.stops.reduce((a, c) => [...a, {
         position: [c.lon, c.lat],
         icon: 'marker',
@@ -50,8 +50,8 @@ class Routes extends Component {
     /* returns new DeckGL Icon Layer displaying all vehicles on given routes */
 
     /* Push vehicle markers into data array */
-    const data = this.props.state.routes.filter(r => r.vehicles).reduce((acc, curr) =>
-      [...acc, ...curr.vehicles.filter(v => v.vid).reduce((a, c) => [...a, {
+    const data = [this.props.route].filter(r => r.routeStates[0].vehicles).reduce((acc, curr) =>
+      [...acc, ...curr.routeStates[0].vehicles.filter(v => v.vid).reduce((a, c) => [...a, {
         position: [c.lon, c.lat],
         icon: 'marker',
         size: 72,
@@ -120,7 +120,7 @@ class Routes extends Component {
 Routes.propTypes = {
   onMarkerClick: propTypes.func.isRequired,
   viewport: propTypes.shape().isRequired,
-  state: propTypes.shape(
+  route: propTypes.shape(
     propTypes.string,
     propTypes.arrayOf(propTypes.object),
   ).isRequired,
@@ -130,15 +130,16 @@ Routes.propTypes = {
 export default createFragmentContainer(
   Routes,
   graphql`
-    fragment Routes_state on State {
-      routes {
+    fragment Routes_route on Route {
+      rid
+      stops {
+        sid
+        lat
+        lon
         name
-        stops {
-          sid
-          lat
-          lon
-          name
-        }
+      }
+      routeStates {
+        vtime
         vehicles {
           vid
           lat


### PR DESCRIPTION
Thanks to https://github.com/trynmaps/tryn-api/pull/14 the client
now has to change its Relay schema as to correspond to the new
format.

The reason such a change is needed is because it's necessary to
do the things we want, like only get data corresponding to open
routes or better handle the drawing of each route.

Now that the states are inside a route,
we can choose to request the vehicles ONLY for the routes that
are selected - which is a big performance gain. At the same
time, only a handful of routes will be open at a time, and there's
another PR that will let the user choose which ones
(https://github.com/trynmaps/tryn-react/pull/24).

However, while the client works - it only displays the state
for the first route. The next step is to have a layer for each
route, that contains all of its states - which is a TODO
described here: https://github.com/trynmaps/tryn-react/issues/27

Tests:
- manually opened web app and dragged around. Worked as expected.