### PR TITLE
41 - show more of the city in default view 

### DIFF
--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -27,7 +27,7 @@ class Map extends Component {
         height: window.innerHeight,
         longitude: -122.41669,
         latitude: 37.7853,
-        zoom: 15,
+        zoom: 13,
         pitch: 0,
         bearing: 0,
       },
@@ -152,6 +152,7 @@ class Map extends Component {
   renderMap() {
     const onViewportChange = viewport => this.setState({ viewport });
     const { trynState } = this.props.trynState;
+    const { routes } = trynState || {};
     const { viewport, settings, geojson } = this.state;
 
     // I don't know what settings used for,
@@ -161,7 +162,7 @@ class Map extends Component {
     const selectedRouteNames = new Set();
     this.selectedRoutes
       .forEach(route => selectedRouteNames.add(route.properties.name));
-    const routeLayers = trynState.routes
+    const routeLayers = (routes || [])
       .filter(route => selectedRouteNames.has(route.rid))
       .reduce((layers, route) => [
         ...layers,


### PR DESCRIPTION
- achieve this by reducing the zoom level from 15 to 13.
- we also want to ensure that the map shows when db isn't available (assign default values of [] and {} to routes and trynState instead of null) - note that the client will still say "failed to fetch" if it can't connect to the API.