### PR TITLE
50 Readme - update onboarding instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 ## Prerequisites
 
+If running tryn-react with the backend running locally:
 - Have tryn-api running and ensure that it's in the same parent directory as this repo.
+- go to `envEndpoints.json` and set the `USE_PROD_ENDPOINT` flag to `false`.
 
-## Getting Started - MacOS
+If running tryn-react using the production API (recommended - do this unless you're working on the backend):
+- Clone tryn-api to the same parent directory as this repo.
+- Checkout the `prod` branch in `tryn-api`.
+
+## Getting Started
 
 See our welcome doc for contribution and deployment guidelines.
 https://docs.google.com/document/d/1KTWRc4EO63_lDxjcp0mmprgrFPfFazWJEy2MwxBuw4E/edit?usp=sharing


### PR DESCRIPTION
Thanks to
https://github.com/trynmaps/tryn-react/commit/d1626c8ff51c1a68d0a2954a93d568b4a0ff6ad6
we can now run the client locally without needing the whole
backend set up. The Readme has been updated to reflect this.